### PR TITLE
Support for tuples via anonymous functions

### DIFF
--- a/src/fn/fn-anonymous-tuple.js
+++ b/src/fn/fn-anonymous-tuple.js
@@ -1,0 +1,18 @@
+'use strict';
+
+require('es6-promise').polyfill();
+
+var debug = require('../helper/debug')('fn-factory');
+
+module.exports = function () {
+  return function fn$anonymousTuple () {
+    debug('fn$anonymousTuple(%j)', arguments);
+    var args = arguments;
+    return new Promise(function (resolve) {
+      var tupleValues = Object.keys(args).map(function (k) { return args[k]; });
+      resolve(tupleValues);
+    });
+  };
+};
+
+module.exports.fnName = 'anonymousTuple';

--- a/src/fn/fn-colors.js
+++ b/src/fn/fn-colors.js
@@ -1,18 +1,4 @@
 'use strict';
 
-require('es6-promise').polyfill();
-
-var debug = require('../helper/debug')('fn-factory');
-
-module.exports = function () {
-  return function fn$colors () {
-    var args = arguments;
-    debug('fn$colors(%j)', arguments);
-    return new Promise(function (resolve) {
-      var colors = Object.keys(args).map(function (k) { return args[k]; });
-      resolve(colors);
-    });
-  };
-};
-
+module.exports = require('./fn-anonymous-tuple');
 module.exports.fnName = 'colors';

--- a/src/fn/fn-factory.js
+++ b/src/fn/fn-factory.js
@@ -7,14 +7,22 @@ var fns = [
   require('./fn-buckets'),
   require('./fn-colors')
 ];
+var fnMap = fns.reduce(function (fnMap, fn) {
+  fnMap[fn.fnName] = fn;
+  return fnMap;
+}, {});
 var fnIdentity = require('./fn-identity');
+var fnAnonymousTuple = require('./fn-anonymous-tuple');
 
 var FnFactory = {
   create: function (fnName, datasource, decl) {
-    for (var i = 0; i < fns.length; i++) {
-      if (fns[i].fnName === fnName) {
-        return fns[i](datasource, decl);
-      }
+    if (fnName === '') {
+      return fnAnonymousTuple();
+    }
+
+    var fn = fnMap[fnName];
+    if (fn) {
+      return fn(datasource, decl);
     }
 
     return fnIdentity(fnName);

--- a/test/acceptance/ramp.test.js
+++ b/test/acceptance/ramp.test.js
@@ -53,4 +53,36 @@ describe('color-ramp', function () {
         done(err);
       });
   });
+
+  it('should use array', function (done) {
+    var cartocss = [
+      '#layer{',
+      '  polygon-opacity: 1;',
+      '  polygon-fill: ramp([area2], (Red, Green, Blue), jenks);',
+      '}'
+    ].join('\n');
+
+    var expectedCartocss = [
+      '#layer{',
+      '  polygon-opacity: 1;',
+      '  polygon-fill: Red;',
+      '  [ area2 > 0 ]{',
+      '    polygon-fill: Green',
+      '  }',
+      '  [ area2 > 1 ]{',
+      '    polygon-fill: Blue',
+      '  }',
+      '}'
+    ].join('\n');
+
+    postcss([postcssTurboCarto.getPlugin()])
+      .process(cartocss)
+      .then(function (result) {
+        assert.equal(result.css, expectedCartocss);
+        done();
+      })
+      .catch(function (err) {
+        done(err);
+      });
+  });
 });

--- a/test/integration/fn-executor.test.js
+++ b/test/integration/fn-executor.test.js
@@ -39,4 +39,37 @@ describe('FnExecutor', function () {
         ]);
       });
   });
+
+  it('should use anonymous-tuple for empty function names', function () {
+    var fn = new FnExecutor(new DummyDatasource(),
+      'ramp',
+      [
+        'population',
+        new FnExecutor(new DummyDatasource(),
+          '', [
+            'Red',
+            'Green',
+            'Blue'
+          ]
+        )
+      ],
+      {
+        parent: {
+          append: function () {}
+        },
+        remove: function () {}
+      }
+    );
+    return fn.exec()
+      .then(function (result) {
+        assert.deepEqual(result, [
+          0,
+          'Red',
+          1,
+          'Green',
+          2,
+          'Blue'
+        ]);
+      });
+  });
 });

--- a/test/unit/fn-anonymous-tuple.test.js
+++ b/test/unit/fn-anonymous-tuple.test.js
@@ -1,0 +1,21 @@
+'use strict';
+
+var assert = require('assert');
+var fnAnonymousTuple = require('../../src/fn/fn-anonymous-tuple');
+
+describe('fn-anonymous-tuple', function () {
+  var fn = fnAnonymousTuple();
+  it('should return given strings', function (done) {
+    fn('red', 'green', 'blue').then(function (result) {
+      assert.deepEqual(result, [ 'red', 'green', 'blue' ]);
+      done();
+    });
+  });
+
+  it('should return given numbers', function (done) {
+    fn(9, 8, 7).then(function (result) {
+      assert.deepEqual(result, [ 9, 8, 7 ]);
+      done();
+    });
+  });
+});


### PR DESCRIPTION
This allows to use a finite list of values as input for other functions.
For instance it allows to:

```css
  marker-width: ramp([pop_max], (1, 2, 10, 20), quantiles));
  marker-fill: ramp([pop_max], (red, green, blue), headtails);
}
```

Closes #21