### PR TITLE
method names are case insensitive

### DIFF
--- a/src/fn/fn-ramp.js
+++ b/src/fn/fn-ramp.js
@@ -141,6 +141,11 @@ function tupleRamp (datasource, column, tuple, method) {
     return Promise.resolve({ramp: ramp, strategy: 'split'}).then(createRampFn(tuple));
   }
 
+  // normalize method
+  if (method) {
+    method = method.toLowerCase();
+  }
+
   return getRamp(datasource, column, tuple.length, method).then(createRampFn(tuple));
 }
 

--- a/test/acceptance/scenarios/should-normalize-method-names.css
+++ b/test/acceptance/scenarios/should-normalize-method-names.css
@@ -1,0 +1,3 @@
+#layer{
+  marker-width: ramp([population], (4, 8, 12), JeNks);
+}

--- a/test/acceptance/scenarios/should-normalize-method-names.expected.css
+++ b/test/acceptance/scenarios/should-normalize-method-names.expected.css
@@ -1,0 +1,9 @@
+#layer{
+  marker-width: 4;
+  [ population > 0 ]{
+    marker-width: 8
+  }
+  [ population > 1 ]{
+    marker-width: 12
+  }
+}


### PR DESCRIPTION
this PR avoids problem with "Jenks" vs "jenks". 

Some people like to write own names starting with a capital letter so this allow it 

cc @rochoa 