### PR TITLE
Ramps using as many values as provided when there are less than tuples

### DIFF
--- a/src/fn/fn-ramp.js
+++ b/src/fn/fn-ramp.js
@@ -196,14 +196,18 @@ function createRampFn (tuple) {
       ramp = ramp.ramp;
     }
 
-    var buckets = tuple.length;
+    var buckets = Math.min(tuple.length, ramp.length);
 
     var i;
     var rampResult = [];
 
-    for (i = 0; i < buckets; i++) {
-      rampResult.push(ramp[i]);
-      rampResult.push(tuple[i]);
+    if (buckets > 0) {
+      for (i = 0; i < buckets; i++) {
+        rampResult.push(ramp[i]);
+        rampResult.push(tuple[i]);
+      }
+    } else {
+      rampResult.push(null, tuple[0]);
     }
 
     return { ramp: rampResult, strategy: strategy };

--- a/test/acceptance/regressions.test.js
+++ b/test/acceptance/regressions.test.js
@@ -4,10 +4,17 @@ var assert = require('assert');
 var postcss = require('postcss');
 var PostcssTurboCarto = require('../../src/postcss-turbo-carto');
 var DummyDatasource = require('../support/dummy-datasource');
+var DummyStrategyDatasource = require('../support/dummy-strategy-datasource');
 
 describe('regressions', function () {
-  function getCartoCss (cartocss, callback) {
-    var postcssTurboCarto = new PostcssTurboCarto(new DummyDatasource());
+  function getCartoCss (cartocss, datasource, callback) {
+    if (!callback) {
+      callback = datasource;
+      datasource = new DummyDatasource();
+    }
+    datasource = datasource || new DummyDatasource();
+
+    var postcssTurboCarto = new PostcssTurboCarto(datasource);
     postcss([postcssTurboCarto.getPlugin()])
       .process(cartocss)
       .then(function (result) {
@@ -62,12 +69,79 @@ describe('regressions', function () {
         '  }',
         '}'
       ].join('\n')
+    },
+    {
+      desc: 'should work with empty results and split strategy',
+      datasource: new DummyStrategyDatasource('split', function () {
+        return [];
+      }),
+      cartocss: [
+        '#layer{',
+        '  marker-width: ramp([population], (10, 20, 30, 40));',
+        '}'
+      ].join('\n'),
+      expectedCartocss: [
+        '#layer{',
+        '  marker-width: 10;',
+        '}'
+      ].join('\n')
+    },
+    {
+      desc: 'should work with empty results and exact strategy',
+      datasource: new DummyStrategyDatasource('exact', function () {
+        return [];
+      }),
+      cartocss: [
+        '#layer{',
+        '  marker-width: ramp([population], (10, 20, 30, 40));',
+        '}'
+      ].join('\n'),
+      expectedCartocss: [
+        '#layer{',
+        '  marker-width: 10;',
+        '}'
+      ].join('\n')
+    },
+    {
+      desc: 'should work with empty results and exact strategy and marker-fill',
+      datasource: new DummyStrategyDatasource('exact', function () {
+        return [];
+      }),
+      cartocss: [
+        '#layer{',
+        '  marker-fill: ramp([population], colorbrewer(Reds));',
+        '}'
+      ].join('\n'),
+      expectedCartocss: [
+        '#layer{',
+        '  marker-fill: #fee5d9;',
+        '}'
+      ].join('\n')
+    },
+    {
+      desc: 'should work when result provides less values than tuples',
+      datasource: new DummyStrategyDatasource('exact', function () {
+        return [1, 2];
+      }),
+      cartocss: [
+        '#layer{',
+        '  marker-fill: ramp([population], colorbrewer(Reds, 7));',
+        '}'
+      ].join('\n'),
+      expectedCartocss: [
+        '#layer{',
+        '  marker-fill: #fee5d9;',
+        '  [ population = "2" ]{',
+        '    marker-fill: #fcbba1',
+        '  }',
+        '}'
+      ].join('\n')
     }
   ];
 
   scenarios.forEach(function (scenario) {
     it(scenario.desc, function (done) {
-      getCartoCss(scenario.cartocss, function (err, cartocssResult) {
+      getCartoCss(scenario.cartocss, scenario.datasource, function (err, cartocssResult) {
         if (err) {
           return done(err);
         }


### PR DESCRIPTION
It defaults to first tuple value when there are no values in ramp.

Fixes #34