### PR TITLE
Return valid metadata value when a datasource returns just one value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Version 0.20.2
+Released 2017-11-29
+ - Fix ramp result that returns undefined values when the datasource returns only one element #73
+
 ## Version 0.20.1
 Released 2017-10-03
  - Upgrade debug to 3.x.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "turbo-carto",
-  "version": "0.20.1",
+  "version": "0.20.2",
   "description": "CartoCSS preprocessor",
   "main": "src/index.js",
   "scripts": {

--- a/src/model/ramp/ramp-result.js
+++ b/src/model/ramp/ramp-result.js
@@ -2,6 +2,7 @@
 
 var TurboCartoError = require('../../helper/turbo-carto-error');
 var postcss = require('postcss');
+var debug = require('../../helper/debug')('ramp-result');
 
 function RampResult (values, filters, mapping) {
   this.values = values;
@@ -238,15 +239,17 @@ RampResult.prototype.processGreaterThanOrEqual = function (column, decl, metadat
       return bucket;
     });
 
+    var lastElementIndex = lastIndex === 0 ? 0 : (lastIndex + 1);
     metadataRule.buckets.push({
       filter: {
         type: FILTER_TYPE.RANGE,
         start: previousFilter,
         end: stats.max
       },
-      value: values[lastIndex + 1]
+      value: values[lastElementIndex]
     });
 
+    debug(metadataRule.buckets);
     metadataHolder.add(metadataRule);
   }
 
@@ -301,13 +304,14 @@ RampResult.prototype.processLessThanOrEqual = function (column, decl, metadataHo
       return bucket;
     });
 
+    var lastElementIndex = lastIndex === 0 ? 0 : (lastIndex + 1);
     metadataRule.buckets.push({
       filter: {
         type: FILTER_TYPE.RANGE,
         start: previousFilter,
         end: stats.max
       },
-      value: values[lastIndex + 1]
+      value: values[lastElementIndex]
     });
 
     metadataHolder.add(metadataRule);

--- a/test/acceptance/metadata.test.js
+++ b/test/acceptance/metadata.test.js
@@ -70,7 +70,7 @@ describe('metadata', function () {
       assert.equal(rule.stats.filter_avg, 8);
 
       var expectedBuckets = [
-        { filter: { type: 'range', start: 8, end: 8 }, value: 8 },
+        { filter: { type: 'range', start: 8, end: 8 }, value: 8 }
       ];
 
       assert.deepEqual(rule.buckets, expectedBuckets);
@@ -146,7 +146,7 @@ describe('metadata', function () {
       assert.equal(rule.stats.filter_avg, 100);
 
       var expectedBuckets = [
-        { filter: { type: 'range', start: 100, end: 100 }, value: 8 },
+        { filter: { type: 'range', start: 100, end: 100 }, value: 8 }
       ];
 
       assert.deepEqual(rule.buckets, expectedBuckets);

--- a/test/acceptance/metadata.test.js
+++ b/test/acceptance/metadata.test.js
@@ -18,7 +18,7 @@ describe('metadata', function () {
       };
     });
     turbocarto(cartocss, jenksDatasource, function (err, result, metadata) {
-      assert.ok(!err);
+      assert.ifError(err);
       assert.equal(metadata.rules.length, 1);
 
       var rule = metadata.rules[0];
@@ -44,6 +44,41 @@ describe('metadata', function () {
     });
   });
 
+  it('should generate a valid metadata for jenks when datasource returns one value', function (done) {
+    var cartocss = [
+      '#layer{',
+      '  marker-width: ramp([pop_max], (8), jenks());',
+      '}'
+    ].join('\n');
+    var jenksDatasource = new DummyDatasource(function () {
+      return {
+        ramp: [ 8 ],
+        stats: { min_val: 8, max_val: 8, avg_val: 8 }
+      };
+    });
+    turbocarto(cartocss, jenksDatasource, function (err, result, metadata) {
+      assert.ifError(err);
+      assert.equal(metadata.rules.length, 1);
+
+      var rule = metadata.rules[0];
+
+      assert.equal(rule.selector, '#layer');
+      assert.equal(rule.prop, 'marker-width');
+      assert.equal(rule.column, 'pop_max');
+      assert.equal(rule.buckets.length, 1);
+
+      assert.equal(rule.stats.filter_avg, 8);
+
+      var expectedBuckets = [
+        { filter: { type: 'range', start: 8, end: 8 }, value: 8 },
+      ];
+
+      assert.deepEqual(rule.buckets, expectedBuckets);
+
+      done();
+    });
+  });
+
   it('should generate a valid metadata for headtails alike datasource', function (done) {
     var cartocss = [
       '#layerheads {',
@@ -58,7 +93,7 @@ describe('metadata', function () {
       };
     });
     turbocarto(cartocss, headtailsDatasource, function (err, result, metadata) {
-      assert.ok(!err);
+      assert.ifError(err);
       assert.equal(metadata.rules.length, 1);
 
       var rule = metadata.rules[0];
@@ -76,6 +111,42 @@ describe('metadata', function () {
         { filter: { type: 'range', start: 1408234, end: 3680157 }, value: 20 },
         { filter: { type: 'range', start: 3680157, end: 7778065 }, value: 26 },
         { filter: { type: 'range', start: 7778065, end: 35676000 }, value: 32 }
+      ];
+
+      assert.deepEqual(rule.buckets, expectedBuckets);
+
+      done();
+    });
+  });
+
+  it('should generate a valid metadata for headtails with datasource that returns one value', function (done) {
+    var cartocss = [
+      '#layerheads {',
+      '  marker-width: ramp([pop_max], (8), headtails());',
+      '}'
+    ].join('\n');
+    var headtailsDatasource = new DummyDatasource(function () {
+      return {
+        ramp: [ 325723 ],
+        strategy: 'split',
+        stats: { min_val: 100, max_val: 100, avg_val: 100 }
+      };
+    });
+    turbocarto(cartocss, headtailsDatasource, function (err, result, metadata) {
+      assert.ifError(err);
+      assert.equal(metadata.rules.length, 1);
+
+      var rule = metadata.rules[0];
+
+      assert.equal(rule.selector, '#layerheads');
+      assert.equal(rule.prop, 'marker-width');
+      assert.equal(rule.column, 'pop_max');
+      assert.equal(rule.buckets.length, 1);
+
+      assert.equal(rule.stats.filter_avg, 100);
+
+      var expectedBuckets = [
+        { filter: { type: 'range', start: 100, end: 100 }, value: 8 },
       ];
 
       assert.deepEqual(rule.buckets, expectedBuckets);
@@ -106,7 +177,7 @@ describe('metadata', function () {
         stats: { min_val: undefined, max_val: undefined, avg_val: undefined } };
     });
     turbocarto(cartocss, headtailsDatasource, function (err, result, metadata) {
-      assert.ok(!err);
+      assert.ifError(err);
       assert.equal(metadata.rules.length, 1);
 
       var rule = metadata.rules[0];


### PR DESCRIPTION
Fixes #73 

This PR fixes a corner case that happens when we have a css rule like this
```css
ramp([pop_density], (#bd0026, #f03b20, #fd8d3c, #fecc5c, #ffffb2), jenks);
```
and the datasource only returns an element leading to havin an `undefined` value in the metadata becuase we're trying to return a non-existent element