### PR TITLE
Buckets calculation and .catch() before .then()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Version 0.20.3
 Released 2017-mm-dd
+ - Fix ramp result when number of buckets equals 2
 
 ## Version 0.20.2
 Released 2017-11-29

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Changelog
 
 ## Version 0.20.3
-Released 2017-mm-dd
- - Fix ramp result when number of buckets equals 2
+Released 2017-07-08
+ - Fix ramp result when number of buckets equals 2 #14075
+ - Move .catch() before .then() when calling postcss.process() #78
 
 ## Version 0.20.2
 Released 2017-11-29

--- a/src/model/ramp/ramp-result.js
+++ b/src/model/ramp/ramp-result.js
@@ -222,7 +222,7 @@ RampResult.prototype.processGreaterThanOrEqual = function (column, decl, metadat
     if (Number.isFinite(stats.min)) {
       previousFilter = stats.min;
     }
-    var lastIndex = 0;
+    var lastIndex = null;
     metadataRule.buckets = filters.slice(range.start, range.end).map(function (filterRaw, index) {
       var bucket = {
         filter: {
@@ -239,7 +239,8 @@ RampResult.prototype.processGreaterThanOrEqual = function (column, decl, metadat
       return bucket;
     });
 
-    var lastElementIndex = lastIndex === 0 ? 0 : (lastIndex + 1);
+    var lastElementIndex = (lastIndex === null) ? 0 : (lastIndex + 1);
+
     metadataRule.buckets.push({
       filter: {
         type: FILTER_TYPE.RANGE,
@@ -287,7 +288,7 @@ RampResult.prototype.processLessThanOrEqual = function (column, decl, metadataHo
     if (Number.isFinite(stats.min)) {
       previousFilter = stats.min;
     }
-    var lastIndex = 0;
+    var lastIndex = null;
     metadataRule.buckets = filters.slice(range.start, range.end).map(function (filterRaw, index) {
       var bucket = {
         filter: {
@@ -304,7 +305,7 @@ RampResult.prototype.processLessThanOrEqual = function (column, decl, metadataHo
       return bucket;
     });
 
-    var lastElementIndex = lastIndex === 0 ? 0 : (lastIndex + 1);
+    var lastElementIndex = (lastIndex === null) ? 0 : (lastIndex + 1);
     metadataRule.buckets.push({
       filter: {
         type: FILTER_TYPE.RANGE,

--- a/src/turbo-carto.js
+++ b/src/turbo-carto.js
@@ -17,10 +17,10 @@ TurboCarto.prototype.getCartocss = function (callback) {
 
   postcss([postCssTurboCarto.getPlugin(this.metadataHolder)])
     .process(this.cartocss)
+    .catch(callback)
     .then(function (result) {
       callback(null, result.css, self.metadataHolder);
-    })
-    .catch(callback);
+    });
 };
 
 TurboCarto.prototype.getMetadata = function (callback) {

--- a/test/acceptance/ramp-buckets-regressions.test.js
+++ b/test/acceptance/ramp-buckets-regressions.test.js
@@ -4,42 +4,42 @@ var assert = require('assert');
 var turbocarto = require('../../src/index');
 var DummyDatasource = require('../support/dummy-datasource');
 
-var scenarios = [
-  {
-    desc: '">" strategy',
-    datasource: new DummyDatasource(function () {
-      return [1];
-    }),
-    turboCartocss: [
-      '#layer{',
-      '  marker-fill: ramp([cartodb_id], cartocolor(SunsetDark, 10), jenks);',
-      '}'
-    ].join('\n'),
-    expectedCartocss: [
-      '#layer{',
-      '  marker-fill: #fcde9c;',
-      '}'
-    ].join('\n')
-  },
-  {
-    desc: '"<" strategy',
-    datasource: new DummyDatasource(function () {
-      return [1];
-    }),
-    turboCartocss: [
-      '#layer{',
-      '  marker-fill: ramp([cartodb_id], cartocolor(SunsetDark, 10), headtails(1));',
-      '}'
-    ].join('\n'),
-    expectedCartocss: [
-      '#layer{',
-      '  marker-fill: #7c1d6f;',
-      '}'
-    ].join('\n')
-  }
-];
-
 describe('conditional ramp-buckets', function () {
+  var scenarios = [
+    {
+      desc: '">" strategy',
+      datasource: new DummyDatasource(function () {
+        return [1];
+      }),
+      turboCartocss: [
+        '#layer{',
+        '  marker-fill: ramp([cartodb_id], cartocolor(SunsetDark, 10), jenks);',
+        '}'
+      ].join('\n'),
+      expectedCartocss: [
+        '#layer{',
+        '  marker-fill: #fcde9c;',
+        '}'
+      ].join('\n')
+    },
+    {
+      desc: '"<" strategy',
+      datasource: new DummyDatasource(function () {
+        return [1];
+      }),
+      turboCartocss: [
+        '#layer{',
+        '  marker-fill: ramp([cartodb_id], cartocolor(SunsetDark, 10), headtails(1));',
+        '}'
+      ].join('\n'),
+      expectedCartocss: [
+        '#layer{',
+        '  marker-fill: #7c1d6f;',
+        '}'
+      ].join('\n')
+    }
+  ];
+  
   scenarios.forEach(function (scenario) {
     it('should generate a valid cartocss for a ramp with only one bucket/value and ' + scenario.desc, function (done) {
       turbocarto(scenario.turboCartocss, scenario.datasource, function (err, result) {
@@ -48,6 +48,125 @@ describe('conditional ramp-buckets', function () {
         }
 
         assert.equal(result, scenario.expectedCartocss);
+        done();
+      });
+    });
+  });
+});
+
+describe('Buckets calculation', function () {
+  function createCartoCSS(numBuckets) {
+    return [
+      '#layer {',
+      '  marker-width: ramp([population], range(1, 100), quantiles(' + numBuckets + '));',
+      '  marker-fill: #EE4D5A;\n  marker-fill-opacity: 0.9;\n',
+      '  marker-allow-overlap: true; \n  marker-line-width: 1; \n',
+      '  marker-line-color: #FFFFFF; \n  marker-line-opacity: 1; \n',
+      '}'
+    ].join('\n');
+  }
+
+  var scenarios = [
+    {
+      desc: 'Buckets: 1',
+      numBuckets: 1,
+      dataSourceStats: { min_val: 1, max_val: 100, avg_val: 50 },
+      ramp: [1],
+      expectedBuckets: [
+        {
+          'filter': {
+            'type': 'range',
+            'start': 1,
+            'end': 100
+          },
+          'value': 1         
+        }
+      ],
+      expectedStats: {
+        filter_avg: 50
+      }
+    },
+    {
+      desc: 'Buckets: 2',
+      numBuckets: 2,
+      dataSourceStats: { min_val: 1, max_val: 100, avg_val: 50 },
+      ramp: [1, 2],
+      expectedBuckets: [
+        {
+          'filter': {
+            'type': 'range',
+            'start': 1,
+            'end': 1
+          },
+          'value': 1
+        },
+        {
+          'filter': {
+            'type': 'range',
+            'start': 1,
+            'end': 100
+          },
+          'value': 100
+        }
+      ],
+      expectedStats: {
+        filter_avg: 50
+      }
+    },
+    {
+      desc: 'Buckets: 3',
+      numBuckets: 3,
+      dataSourceStats: { min_val: 1, max_val: 100, avg_val: 50 },
+      ramp: [1, 2, 3],
+      expectedBuckets: [
+        {
+          'filter': {
+            'type': 'range',
+            'start': 1,
+            'end': 1
+          },
+          'value': 1
+        },
+        {
+          'filter': {
+            'type': 'range',
+            'start': 1,
+            'end': 2
+          },
+          'value': 50.5
+        },
+        {
+          'filter': {
+            'type': 'range',
+            'start': 2,
+            'end': 100
+          },
+          'value': 100
+        }
+      ],
+      expectedStats: {
+        filter_avg: 50
+      }
+    }
+  ];
+
+  scenarios.forEach(function (scenario) {
+    it(scenario.desc, function (done) {
+      var datasource = new DummyDatasource(function () {
+        return {
+          ramp: scenario.ramp,
+          strategy: '>',
+          stats: scenario.dataSourceStats
+        };
+      });
+
+      var cartocss = createCartoCSS(scenario.numBuckets);
+
+      turbocarto(cartocss, datasource, function (err, result, metadata) {
+        assert.ifError(err);
+
+        assert.equal(metadata.rules[0].buckets.length, scenario.numBuckets);
+        assert.deepEqual(metadata.rules[0].buckets, scenario.expectedBuckets);  
         done();
       });
     });

--- a/test/acceptance/ramp-buckets-regressions.test.js
+++ b/test/acceptance/ramp-buckets-regressions.test.js
@@ -39,7 +39,7 @@ describe('conditional ramp-buckets', function () {
       ].join('\n')
     }
   ];
-  
+
   scenarios.forEach(function (scenario) {
     it('should generate a valid cartocss for a ramp with only one bucket/value and ' + scenario.desc, function (done) {
       turbocarto(scenario.turboCartocss, scenario.datasource, function (err, result) {
@@ -55,7 +55,7 @@ describe('conditional ramp-buckets', function () {
 });
 
 describe('Buckets calculation', function () {
-  function createCartoCSS(numBuckets) {
+  function createCartoCSS (numBuckets) {
     return [
       '#layer {',
       '  marker-width: ramp([population], range(1, 100), quantiles(' + numBuckets + '));',
@@ -79,7 +79,7 @@ describe('Buckets calculation', function () {
             'start': 1,
             'end': 100
           },
-          'value': 1         
+          'value': 1
         }
       ],
       expectedStats: {
@@ -166,7 +166,7 @@ describe('Buckets calculation', function () {
         assert.ifError(err);
 
         assert.equal(metadata.rules[0].buckets.length, scenario.numBuckets);
-        assert.deepEqual(metadata.rules[0].buckets, scenario.expectedBuckets);  
+        assert.deepEqual(metadata.rules[0].buckets, scenario.expectedBuckets);
         done();
       });
     });


### PR DESCRIPTION
This PR fixes 2 issues:
* Bubble legends with 2 buckets are wrongly rendered https://github.com/CartoDB/cartodb/issues/14075
* Move .catch() before .then() when calling postcss.process() https://github.com/CartoDB/turbo-carto/issues/78
