### PR TITLE
revert .then() .catch() call order until we upgrade to node8/10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 # Changelog
 
 ## Version 0.20.4
-Released 2018-XX-XX
- - 
+Released 2018-07-12
+ - revert .then() .catch() call order until we upgrade to node8/10 #78
 
 ## Version 0.20.3
 Released 2018-07-08

--- a/src/turbo-carto.js
+++ b/src/turbo-carto.js
@@ -17,10 +17,10 @@ TurboCarto.prototype.getCartocss = function (callback) {
 
   postcss([postCssTurboCarto.getPlugin(this.metadataHolder)])
     .process(this.cartocss)
-    .catch(callback)
     .then(function (result) {
       callback(null, result.css, self.metadataHolder);
-    });
+    })
+    .catch(callback);
 };
 
 TurboCarto.prototype.getMetadata = function (callback) {


### PR DESCRIPTION
Newer versions of node (8/9/10) complain about a`UnhandledPromiseRejectionWarning`

This PR [reverts](https://github.com/CartoDB/turbo-carto/pull/79) the order in which `.then()` and `.catch()` are called in order to catch all possible exceptions

Original issue in Windshaft-cartodb: https://github.com/CartoDB/Windshaft-cartodb/issues/1000#event-1727647170