### PR TITLE
Fix evil ramp unhandled exception

### DIFF
--- a/src/fn/fn-buckets.js
+++ b/src/fn/fn-buckets.js
@@ -49,24 +49,18 @@ module.exports.createBucketsFn = function (datasource, alias, defaultStrategy) {
   return function fn$bucketsFn (numBuckets) {
     debug('fn$%s(%j)', alias, arguments);
     debug('Using "%s" datasource to calculate %s', datasource.getName(), alias);
-    return new Promise(function (resolve, reject) {
+    return new Promise(function (resolve) {
       return resolve(new LazyFiltersResult(function (column, strategy) {
         return fnBuckets(datasource)(column, alias, numBuckets).then(function (filters) {
           filters.strategy = strategy || defaultStrategy;
           return new Promise(function (resolve) {
             return resolve(filters);
-          })
-            .catch(function (err) {
-              reject(err);
-            });
-        })
-          .catch(function (err) {
-            reject(err);
           });
+        });
       }));
     })
-      .catch(function (e) {
-        return (e);
+      .catch(function (err) {
+        return (err);
       });
   };
 };

--- a/src/fn/fn-buckets.js
+++ b/src/fn/fn-buckets.js
@@ -35,7 +35,10 @@ function fnBuckets (datasource) {
         }
         resolve(new FiltersResult(filters, strategy, stats, meta));
       });
-    });
+    })
+      .catch(function (e) {
+        return (e);
+      });
   };
 }
 
@@ -46,15 +49,24 @@ module.exports.createBucketsFn = function (datasource, alias, defaultStrategy) {
   return function fn$bucketsFn (numBuckets) {
     debug('fn$%s(%j)', alias, arguments);
     debug('Using "%s" datasource to calculate %s', datasource.getName(), alias);
-    return new Promise(function (resolve) {
+    return new Promise(function (resolve, reject) {
       return resolve(new LazyFiltersResult(function (column, strategy) {
         return fnBuckets(datasource)(column, alias, numBuckets).then(function (filters) {
           filters.strategy = strategy || defaultStrategy;
           return new Promise(function (resolve) {
             return resolve(filters);
+          })
+            .catch(function (err) {
+              reject(err);
+            });
+        })
+          .catch(function (err) {
+            reject(err);
           });
-        });
       }));
-    });
+    })
+      .catch(function (e) {
+        return (e);
+      });
   };
 };

--- a/src/fn/fn-buckets.js
+++ b/src/fn/fn-buckets.js
@@ -36,8 +36,8 @@ function fnBuckets (datasource) {
         resolve(new FiltersResult(filters, strategy, stats, meta));
       });
     })
-      .catch(function (e) {
-        return (e);
+      .catch(function (err) {
+        return (err);
       });
   };
 }

--- a/test/acceptance/regressions.test.js
+++ b/test/acceptance/regressions.test.js
@@ -216,4 +216,27 @@ describe('regressions', function () {
       });
     });
   });
+
+  it('should return an error if it receives an evil ramp (instead of unhandled exception)', function (done) {
+    // NOTE the missing first param (the column) in the ramp
+    var cartocss = [
+      '#layercat{',
+      '  marker-width: ramp(, cartocolor(Safe), category(3));',
+      '}'
+    ].join('\n');
+    var headtailsDatasource = new DummyDatasource(function () {
+      return {
+        ramp: [
+          'United States of America',
+          'Russia',
+          'China'
+        ],
+        strategy: 'exact',
+        stats: { min_val: undefined, max_val: undefined, avg_val: undefined } };
+    });
+    turbocarto(cartocss, headtailsDatasource, function (err, result, metadata) {
+      assert.ifError(err);
+      done();
+    });
+  });
 });

--- a/test/acceptance/regressions.test.js
+++ b/test/acceptance/regressions.test.js
@@ -234,9 +234,13 @@ describe('regressions', function () {
         strategy: 'exact',
         stats: { min_val: undefined, max_val: undefined, avg_val: undefined } };
     });
-    turbocarto(cartocss, headtailsDatasource, function (err, result, metadata) {
-      assert.ifError(err);
-      done();
+    turbocarto(cartocss, headtailsDatasource, function (err /*, result, metadata */) {
+      if (err) {
+        // We're expecting this error
+        assert.strictEqual(err.name, 'TurboCartoError');
+        assert.strictEqual(err.message, 'Failed to process "marker-width" property: column.replace is not a function');
+        done();
+      }
     });
   });
 });


### PR DESCRIPTION
This adds a test case that reproduces a problem that makes the tiler die with a wrong cartocss.

It fixes the problem by adding a few `catch`'es to deal with exceptions and rejected promises, avoiding the dreaded `UnhandledPromiseRejectionWarning`, which causes Windshaft-cartodb to die because of the unhandled exception.

Now, instead of raising the exception, it is returned to the caller.