### PR TITLE
Proper fix for evil ramp unhandled exception

### DIFF
--- a/src/fn/fn-ramp.js
+++ b/src/fn/fn-ramp.js
@@ -188,8 +188,22 @@ function strategyFromMapping (mapping) {
 function compatibilityValuesRamp (datasource, column, args) {
   var values = args[0];
   var method = (args[1] || 'quantiles').toLowerCase();
-  var numBuckets = values.getLength();
-  return getRamp(datasource, column, numBuckets, method).then(compatibilityCreateRampFn(values));
+
+  if (values.is(LazyFiltersResult)) {
+    var mapping = args[2];
+    var strategy = strategyFromMapping(mapping);
+
+    return values.getLength(column, strategy)
+      .then(function (numBuckets) {
+        return getRamp(datasource, column, numBuckets, method);
+      })
+      .then(compatibilityCreateRampFn(values));
+  } else {
+    var numBuckets = values.getLength();
+
+    return getRamp(datasource, column, numBuckets, method)
+      .then(compatibilityCreateRampFn(values));
+  }
 }
 
 /**

--- a/src/model/lazy-filters-result.js
+++ b/src/model/lazy-filters-result.js
@@ -16,3 +16,7 @@ module.exports = LazyFiltersResult;
 LazyFiltersResult.prototype.get = function (column, strategy) {
   return this.filterGenerator(column, strategy);
 };
+
+LazyFiltersResult.prototype.getLength = function (column, strategy) {
+  return this.get(column, strategy);
+};

--- a/test/acceptance/regressions.test.js
+++ b/test/acceptance/regressions.test.js
@@ -216,4 +216,31 @@ describe('regressions', function () {
       });
     });
   });
+
+  it('should return an error if it receives an evil ramp (instead of unhandled exception)', function (done) {
+    // NOTE the missing first param (the column) in the ramp
+    var cartocss = [
+      '#layercat{',
+      '  marker-width: ramp(, cartocolor(Safe), category(3));',
+      '}'
+    ].join('\n');
+    var headtailsDatasource = new DummyDatasource(function () {
+      return {
+        ramp: [
+          'United States of America',
+          'Russia',
+          'China'
+        ],
+        strategy: 'exact',
+        stats: { min_val: undefined, max_val: undefined, avg_val: undefined } };
+    });
+    turbocarto(cartocss, headtailsDatasource, function (err /*, result, metadata */) {
+      if (err) {
+        // We're expecting this error
+        assert.strictEqual(err.name, 'TurboCartoError');
+        assert.strictEqual(err.message, 'Failed to process "marker-width" property: column.replace is not a function');
+        done();
+      }
+    });
+  });
 });


### PR DESCRIPTION
This adds a test case that reproduces a problem that makes the tiler die with a wrong cartocss.

It fixes it by differenciating when `LazyFilterResult` is a promise or a value and handling it as appropriate, thanks to @dgaubert .